### PR TITLE
Fix broken docs links reported by Algolia crawler

### DIFF
--- a/docs/docs/guides/running-transforms.mdx
+++ b/docs/docs/guides/running-transforms.mdx
@@ -264,6 +264,6 @@ artifact_definitions:
 
 ## Further Resources
 
-- [Infrahub Transforms Documentation](https://docs.infrahub.app/topics/transforms)
-- [infrahubctl CLI Reference](https://docs.infrahub.app/reference/cli)
+- [Infrahub Transforms Documentation](https://docs.infrahub.app/topics/transformation)
+- [infrahubctl CLI Reference](https://docs.infrahub.app/reference/infrahub-cli)
 - [Jinja2 Template Documentation](https://jinja.palletsprojects.com/)


### PR DESCRIPTION
## Summary

- Fix `/reference/cli` → `/reference/infrahub-cli` (was returning 404)
- Fix `/topics/transforms` → `/topics/transformation` (was returning 404)

Both broken links are in `docs/docs/guides/running-transforms.mdx` and were identified by the Algolia crawler monitoring dashboard.

## Test plan

- [ ] Verify https://docs.infrahub.app/reference/infrahub-cli resolves
- [ ] Verify https://docs.infrahub.app/topics/transformation resolves
- [ ] Re-crawl in Algolia after deploy and confirm 404s are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)